### PR TITLE
:sparkles: Support for modifier keys and many bugfixes!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "svelte-keyboard-shortcuts",
 	"version": "0.0.1",
+	"license": "MIT",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/src/app.css
+++ b/src/app.css
@@ -5,7 +5,7 @@ kbd {
 	display: inline-block;
 	border: 1px solid #ccc;
 	border-radius: 4px;
-	padding:0 0.5em;
+	padding: 0 0.5em;
 	margin: 0 0.2em;
 	box-shadow:
 		0 1px 0px rgba(0, 0, 0, 0.2),
@@ -14,15 +14,15 @@ kbd {
 	color: black;
 }
 
-.highlighted{
+.highlighted {
 	background-color: yellow;
 }
 
-a{
-	color:blue
+a {
+	color: blue;
 }
 
 html,
 body {
-    @apply h-full overflow-hidden;
+	@apply h-full overflow-hidden;
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,15 +1,13 @@
 <!doctype html>
 <html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%sveltekit.head%
+	</head>
 
-<head>
-	<meta charset="utf-8" />
-	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	%sveltekit.head%
-</head>
-
-<body data-sveltekit-preload-data="hover">
-	<div style="display: contents">%sveltekit.body%</div>
-</body>
-
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
 </html>

--- a/src/lib/components/Shortcuts.svelte
+++ b/src/lib/components/Shortcuts.svelte
@@ -1,11 +1,35 @@
 <script lang="ts">
-	import { setAppOptions, keyPressesState, resetKeyPressesState } from '$lib/shortcuts.svelte.js';
+	import {
+		setAppOptions,
+		keyPressesState,
+		modifiersState,
+		modifiersMapping,
+		type PressModifiers,
+		resetKeyPressesState
+	} from '$lib/shortcuts.svelte.js';
 
 	import type { AllKeys, AppOptions } from '$lib/shortcuts.svelte.js';
 	let { options }: { options?: AppOptions } = $props();
 	options = setAppOptions(options);
 
 	let timer = 0;
+
+	const lettersPattern = /^Key[A-Z]$/;
+	const digitsPattern = /^Digit[0-9]$/;
+	const modifiersPattern = /^(Alt|Control|Shift|Meta)(Right|Left)$/;
+	const symbolsMap: Record<string, AllKeys> = {
+		BracketLeft: '[',
+		BracketRight: ']',
+		Semicolon: ';',
+		Quote: "'",
+		Backslash: '\\',
+		Minus: '-',
+		Equal: '=',
+		Comma: ',',
+		Period: '.',
+		Slash: '/',
+		Backquote: '`'
+	};
 </script>
 
 <svelte:window
@@ -17,10 +41,35 @@
 		if (event.key === 'Escape') {
 			eventTarget.blur();
 		}
+		for (const [modifier, key] of Object.entries(modifiersMapping)) {
+			modifiersState[modifier as PressModifiers] = event[key];
+		}
 
 		// Push on other keys
 		if (exclude.indexOf(eventTarget.tagName.toLowerCase()) === -1) {
-			keyPressesState.push(event.key as AllKeys);
+			// Fallback for mobile devices
+			if (!event.code) {
+				keyPressesState.push(event.key as AllKeys);
+			} else {
+				if (lettersPattern.test(event.code)) {
+					// Store any letter keypresses as lowercase letters
+					keyPressesState.push(event.code.slice(3).toLowerCase() as AllKeys);
+				} else if (digitsPattern.test(event.code)) {
+					// Shorten DigitN patterns
+					keyPressesState.push(event.code.slice(5) as AllKeys);
+				} else if (modifiersPattern.test(event.code)) {
+					// Strip position from modifier keys bc everyone will forget the existence or right-hand keys anyways
+					keyPressesState.push(modifiersPattern.exec(event.code)![1] as AllKeys);
+				} else if (event.code in symbolsMap) {
+					// Shorten other main keys
+					keyPressesState.push(symbolsMap[event.code as keyof typeof symbolsMap]);
+				} else if (event.code === 'Help') {
+					// "Help" and "Insert" both behave differently in Firefox and Chrome, treat both as "Insert"
+					keyPressesState.push('Insert');
+				} else {
+					keyPressesState.push(event.code as AllKeys);
+				}
+			}
 			clearTimeout(timer);
 			timer = setTimeout(() => {
 				resetKeyPressesState();

--- a/src/lib/shortcuts.svelte.ts
+++ b/src/lib/shortcuts.svelte.ts
@@ -115,7 +115,6 @@ type EditingKeys =
 	| 'Insert'
 	| 'Paste'
 	| 'Find'
-	| 'Help'
 	| 'Undo';
 
 export type AllKeys =

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,11 @@
 		>
 		<div use:shortcuts={{ keys: ['c'] }} tabindex="2">Press C to Focus on me!</div>
 		<div use:shortcuts={{ keys: ['Delete'] }} tabindex="2">Press Delete to Focus on me!</div>
+		<div use:shortcuts={{ keys: ['`'] }} tabindex="2">Press ` to Focus on me!</div>
+		<div
+			use:shortcuts={{ keys: ['z'], modifiers: [['Control', 'Shift'], ['Meta', 'Shift']] }}
+			tabindex="2"
+		>Press Ctrl+Shift+Z (or Meta+Shift+Z) to Focus on me!</div>
 
 		<label>
 			F to focus on me

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -4,5 +4,5 @@
 
 <div class="flex h-full w-full flex-col items-center justify-center">
 	<p>Created by Chris.</p>
-	<a href="/" use:shortcuts={{ keys: ['ArrowLeft'] }}>⬅️ back</a>
+	<a href="/" use:shortcuts={{ keys: ['ArrowLeft'] }}>back</a>
 </div>


### PR DESCRIPTION
Well, it would be quicker if I just used my own framework-agnostic keybind library from previous project, but nonetheless, here is the overhaul of an implementation of yours.

This pullrequest:

* Removes console.log spam on `use:`, well, use.
* Applies prettier on all files, fixing styling inconsistencies
* Adds the missing "license" field in `package.json`
* Changes key detection behavior to check `KeyboardEvent['code']` first instead of just `KeyboardEvent['key']`, resulting in layout-agnostic behaviour. Your initial implementation never worked when a language other than English was enabled, and failed when Shift or CapsLock was active. `KeyboardEvent['key']` will be used when `KeyboardEvent['code']` is empty, which is the case for mobile devices.
* Removes non-existing keys from typings. Where did you get them? Some keys were fixed; notably, the keypad keys. [Reference](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values).
* Adds support for keys `[`, `]`, `;`, `'`, `.`, `/`, `-`, `=`, and `~`.
* Add code shorteners and normalizers so that `KeyQ` becomes `q`, `ShiftRight`/`ShiftLeft` are just `Shift`, among other stuff. In result, the `keys` fields in `use:` stay the same.
* Adds a normalizer for `Help`/`Insert` keycodes. In `keys` option, use just `"Insert"`.
* Modifiers will also be drawn as <kbd>kbd</kbd>
* <kbd>ArrowLeft</kbd> and such display as <kbd>←</kbd> arrows.
* Demo page updated to include modifier keys example.

Example usage of modifier keys:
```svelte
<button onclick={undo} use:shortcuts={{
    keys: ['a'],
    modifiers: false
}}>Select all (A)</button>
<button onclick={undo} use:shortcuts={{
    keys: ['a'],
    modifiers: ['Alt']
}}>Invert selection (Alt+A)</button>
<button onclick={undo} use:shortcuts={{
    keys: ['z'],
    modifiers: [['Control'], ['Meta']]
}}>Undo (Ctrl+Z)</button>
<button onclick={redo} use:shortcuts={{
    keys: ['z'],
    modifiers: [['Shift', 'Control'], ['Shift', 'Meta']]
}}>Redo (Ctrl+Shift+Z)</button>
```

Explanation:
* New `modifiers` field can be undefined, `false`, `PressModifiers[]`, or `PressModifiers[][]`.
* When unspecified, modifiers' state is **ignored**. Meaning that any modifiers can be pressed and it will trigger a hotkey.
* When set to `false`, it is required that modifier keys are **not** pressed.
* When set to `PressModifiers[]`, all modifiers in the array must be active for hotkey to trigger (AND operator).
* `PressModifiers[][]` is parsed as an OR -> AND structure: `[['Shift', 'Control'], ['Shift', 'Meta']]` means "either Shift+Control or Shift+Meta".
* Strict comparison is performed; Ctrl+Z will not trigger if Ctrl+Shift+Z was pressed.

Other feedback:
* Vercel adapter dependency forces you to use a specific version range of Node when developing (v22 and below). Before forking your library, I didn't even had Node installed as I use Bun in all other projects. Bun mimics as Node v24+ and thus the adapter is a problem. It is really not needed for a static 2-page demo.